### PR TITLE
Fixing the downloads section not rendering

### DIFF
--- a/_includes/github-issues.html
+++ b/_includes/github-issues.html
@@ -120,3 +120,4 @@
     </div>
   </div>
 </div>
+<script src="{{ site.baseurl }}/assets/js/githubIssues.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,8 +17,6 @@
 
 {% include copyright.html %}
 <script src="{{ site.baseurl }}/assets/js/jquery.smoothscroll.js"></script>
-<script src="{{ site.baseurl }}/assets/js/downloads.js"></script>
-<script src="{{ site.baseurl }}/assets/js/githubIssues.js"></script>
 <script src="{{ site.baseurl }}/assets/js/functions.js"></script>
 </body>
 </html>

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -1,4 +1,19 @@
 (function() {
+    function getTelegramData() {
+        $.ajax({
+            url: Tari.telegramCachingURL,
+            headers: { "Access-Control-Allow-Origin": "*" },
+            success: function(res) {
+                const { online = "" } = res;
+                const telegramCountEl = document.getElementById("telegram-counter");
+                const mobileTelegramCountEl = document.getElementById("mobile-telegram-counter");
+                if (telegramCountEl) {
+                    telegramCountEl.innerText = online.trim() + " PEOPLE ONLINE";
+                    mobileTelegramCountEl.innerText = online.trim() + " PEOPLE ONLINE";
+                }
+            }
+        });
+    }
     const site = window.location.origin;
     let updateHash = false;
     const homepage = window.location.href.split('/#')[0] === site || window.location.href.replace(/\/$/, "") === site;
@@ -86,13 +101,8 @@
                 const hash = window.location.hash.substring(1); //Puts hash in variable, and removes the # character
                 href = "#" + hash;
                 $(href).scrollToElement(function () {
-                    if (homepage) {
-                        getIssuesData();
-                    }
                 });
 
-            } else if (!window.location.hash) {
-                getIssuesData();
             }
         }
 
@@ -199,7 +209,7 @@
 	         $(this).removeClass("faq-active");
 	         $(this).find('.arrow').removeClass("arrow-rotate");
 	         $(this).addClass("faq-not-active");
-	     }		
+	     }
 	 });
 
 	});

--- a/assets/js/githubIssues.js
+++ b/assets/js/githubIssues.js
@@ -1,18 +1,4 @@
-function getTelegramData() {
-  $.ajax({
-    url: Tari.telegramCachingURL,
-    headers: { "Access-Control-Allow-Origin": "*" },
-    success: function(res) {
-      const { online = "" } = res;
-      const telegramCountEl = document.getElementById("telegram-counter");
-      const mobileTelegramCountEl = document.getElementById("mobile-telegram-counter");
-      if (telegramCountEl) {
-        telegramCountEl.innerText = online.trim() + " PEOPLE ONLINE";
-        mobileTelegramCountEl.innerText = online.trim() + " PEOPLE ONLINE";
-      }
-    }
-  });
-}
+
 //get data
 function getIssuesData() {
   $.ajax({
@@ -220,3 +206,5 @@ function daysBetween(date1String, date2String) {
   let d2 = new Date(date2String);
   return Math.round((d2 - d1) / (1000 * 3600 * 24));
 }
+
+getIssuesData()

--- a/downloads.html
+++ b/downloads.html
@@ -16,25 +16,25 @@ class: subpage blog
     >
       <div class="new-section">
         <h1>Downloads</h1>
-        <p>Help secure the network, and mine testnet Tari (tXTR) while you do it. 
+        <p>Help secure the network, and mine testnet Tari (tXTR) while you do it.
         </p>
-        
+
       </div>
       <p>The Tari base node software is designed to be easy to set up and to run silently in the background. <a href="https://github.com/tari-project/tari/blob/development/README.md" target="_blank">Learn more about using the binaries</a>. Note: if your operating system does not currently have binary, you must compile from source.
       </p>
       <div class="updates-banner">
         <div class="d-flex">
-          
+
           <p>We're constantly making improvements to Tari. <a href="{{ site.baseurl }}/updates"><img style="max-width: 20px; margin-left: 20px; margin-right: 5px;" src="{{ site.baseurl }}/assets/img/updates-icon.svg" alt="" /> View the latest updates here</a>.</p>
-          
+
         </div>
         <p>
       </div>
-        
+
       </div>
       {% include downloads.html %}
     </div>
   </div>
 </section>
-
+<script src="{{ site.baseurl }}/assets/js/downloads.js"></script>
 <!--  downloads end-->


### PR DESCRIPTION
Moved scripts to only trigger on the pages that actually require it. Downloads only loads the downloads.js when it loads, and github issues only attempt to render when they load.