### PR TITLE
replace freenode with libera chat

### DIFF
--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -33,7 +33,7 @@
 
 
 <div class="col-lg-6 col-md-6 col-sm-12">
-  <a href="https://freenode.net/" target="_blank">
+  <a href="https://libera.chat/" target="_blank">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
         <div class="col-3 align-self-center">
@@ -76,7 +76,7 @@
 
 
 <div class="col-lg-6 col-md-6 col-sm-12">
-  <a href="https://freenode.net/" target="_blank">
+  <a href="https://libera.chat/" target="_blank">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
         <div class="col-3 align-self-center">
@@ -117,7 +117,7 @@
 
 
 <div class="col-lg-6 col-md-6 col-sm-12">
-  <a href="https://freenode.net/" target="_blank">
+  <a href="https://libera.chat/" target="_blank">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
         <div class="col-3 align-self-center">

--- a/_updates/2021-03-15-update-50.md
+++ b/_updates/2021-03-15-update-50.md
@@ -78,4 +78,4 @@ Instructions on running the tests are available in the [README](https://github.c
 
 The tests verify many scenarios, including [transaction propagation](https://github.com/tari-project/tari/blob/development/integration_tests/features/Mempool.feature), [re-orgs](https://github.com/tari-project/tari/blob/development/integration_tests/features/Reorgs.feature), [block propagation](https://github.com/tari-project/tari/blob/development/integration_tests/features/Propagation.feature) and [syncing](https://github.com/tari-project/tari/blob/development/integration_tests/features/Sync.feature),  and even [sending thousands of transactions](https://github.com/tari-project/tari/blob/development/integration_tests/features/StressTest.feature).
 
-There's not much more to it, and this is a really simple entry point to contribute. If you get stuck, pop into the #tari-dev IRC on freenode and ask a question.
+There's not much more to it, and this is a really simple entry point to contribute. If you get stuck, pop into the #tari-dev IRC on ~~freenode~~ Libera.Chat and ask a question.

--- a/index.html
+++ b/index.html
@@ -559,7 +559,7 @@ class: subpage home
         <p>Found a bug? If it's a noncritical bug, please report it as a GitHub issue <a href="https://github.com/tari-project/tari/issues/new?assignees=&labels=bug-report&template=bug_report.md&title=%5BThanks%20for%20making%20Tari%20better%5D" target="_blank">here</a>. Thank you for helping to make the Tari project more robust, and reliable.</p>
 
         <h3>The Beginning of Your Journey</h3>
-        <p>The Tari project is undergoing continuous evolution. As a result there are always issues to tackle and improvements to make. The Tari community makes an effort to maintain a number of open issues that are a good place to start for new contributors. These issues are labeled in Tari project repos as “good first issue” and are usually refreshed every few months. Have questions? Please feel free to ask any question you have in #tari-dev on freenode, or on <a href="https://t.me/tariproject" target="_blank">Telegram</a>. </p>
+        <p>The Tari project is undergoing continuous evolution. As a result there are always issues to tackle and improvements to make. The Tari community makes an effort to maintain a number of open issues that are a good place to start for new contributors. These issues are labeled in Tari project repos as “good first issue” and are usually refreshed every few months. Have questions? Please feel free to ask any question you have in #tari-dev on Libera.Chat, or on <a href="https://t.me/tariproject" target="_blank">Telegram</a>. </p>
 
         <h3>Protocol Issues</h3>
         <p>Oftentimes new contributors start with documentation related issues that tend to be quick wins and help them understand the protocol in greater detail before moving towards test writing and focusing on core protocol code. But feel free to choose your own adventure
@@ -567,7 +567,7 @@ class: subpage home
 
         {% include github-issues.html %}
 
-        <p>Once you’ve found an issue you wish to pursue, stop by  #tari-dev on #freenode and someone will assign you the issue in GitHub. Before you start, please read the project <a href="https://github.com/tari-project/tari/blob/development/Contributing.md" target="_blank">contributing guidelines</a> which includes a style guide and a useful PR template. Thank you for your contributions to the Tari project. Together we can make useful freedom enhancing software that everyone wants to use.  </p>
+        <p>Once you’ve found an issue you wish to pursue, stop by  #tari-dev on Libera.Chat and someone will assign you the issue in GitHub. Before you start, please read the project <a href="https://github.com/tari-project/tari/blob/development/Contributing.md" target="_blank">contributing guidelines</a> which includes a style guide and a useful PR template. Thank you for your contributions to the Tari project. Together we can make useful freedom enhancing software that everyone wants to use.  </p>
 
 
       </div>

--- a/updates.html
+++ b/updates.html
@@ -14,7 +14,7 @@ class: subpage blog
     <p>The latest updates from developers contributing to the Tari protocol.</p>
 
   </div>
-  <p>Have questions or want to contribute? Join the community discussion on <a href="https://t.me/tariproject" target="_blank">Telegram</a> or #tari-dev on <a href="https://freenode.net/" target="_blank">freenode</a>.</p>
+  <p>Have questions or want to contribute? Join the community discussion on <a href="https://t.me/tariproject" target="_blank">Telegram</a> or #tari-dev on <a href="https://libera.chat/" target="_blank">Libera.Chat</a>.</p>
 
     <div
       style="max-width: 90rem;"


### PR DESCRIPTION
Replaced all instances of legacy freenode links with Libera.Chat ones.

One blog post mentioned freenode as well, I used strikethrough here to preserve the historic contents of that post while still containing up-to-date info.