### PR TITLE
create RSS feed from "updates" posts

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,17 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom" ><generator uri="https://jekyllrb.com/" version="4.0.0">Jekyll</generator><link href="http://localhost:4000/feed.xml" rel="self" type="application/atom+xml" /><link href="http://localhost:4000/" rel="alternate" type="text/html" /><updated>2020-02-18T12:33:54+01:00</updated><id>http://localhost:4000/feed.xml</id><title type="html">Your awesome title</title><subtitle>Write an awesome description for your new site here. You can edit this line in _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description.</subtitle><entry><title type="html">Welcome to Jekyll!</title><link href="http://localhost:4000/jekyll/update/2020/02/18/welcome-to-jekyll.html" rel="alternate" type="text/html" title="Welcome to Jekyll!" /><published>2020-02-18T12:33:05+01:00</published><updated>2020-02-18T12:33:05+01:00</updated><id>http://localhost:4000/jekyll/update/2020/02/18/welcome-to-jekyll</id><content type="html" xml:base="http://localhost:4000/jekyll/update/2020/02/18/welcome-to-jekyll.html">&lt;p&gt;You’ll find this post in your &lt;code class=&quot;highlighter-rouge&quot;&gt;_posts&lt;/code&gt; directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run &lt;code class=&quot;highlighter-rouge&quot;&gt;jekyll serve&lt;/code&gt;, which launches a web server and auto-regenerates your site when a file is updated.&lt;/p&gt;
-
-&lt;p&gt;Jekyll requires blog post files to be named according to the following format:&lt;/p&gt;
-
-&lt;p&gt;&lt;code class=&quot;highlighter-rouge&quot;&gt;YEAR-MONTH-DAY-title.MARKUP&lt;/code&gt;&lt;/p&gt;
-
-&lt;p&gt;Where &lt;code class=&quot;highlighter-rouge&quot;&gt;YEAR&lt;/code&gt; is a four-digit number, &lt;code class=&quot;highlighter-rouge&quot;&gt;MONTH&lt;/code&gt; and &lt;code class=&quot;highlighter-rouge&quot;&gt;DAY&lt;/code&gt; are both two-digit numbers, and &lt;code class=&quot;highlighter-rouge&quot;&gt;MARKUP&lt;/code&gt; is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.&lt;/p&gt;
-
-&lt;p&gt;Jekyll also offers powerful support for code snippets:&lt;/p&gt;
-
-&lt;figure class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-ruby&quot; data-lang=&quot;ruby&quot;&gt;&lt;span class=&quot;k&quot;&gt;def&lt;/span&gt; &lt;span class=&quot;nf&quot;&gt;print_hi&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;nb&quot;&gt;name&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;)&lt;/span&gt;
-  &lt;span class=&quot;nb&quot;&gt;puts&lt;/span&gt; &lt;span class=&quot;s2&quot;&gt;&quot;Hi, &lt;/span&gt;&lt;span class=&quot;si&quot;&gt;#{&lt;/span&gt;&lt;span class=&quot;nb&quot;&gt;name&lt;/span&gt;&lt;span class=&quot;si&quot;&gt;}&lt;/span&gt;&lt;span class=&quot;s2&quot;&gt;&quot;&lt;/span&gt;
-&lt;span class=&quot;k&quot;&gt;end&lt;/span&gt;
-&lt;span class=&quot;n&quot;&gt;print_hi&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'Tom'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;)&lt;/span&gt;
-&lt;span class=&quot;c1&quot;&gt;#=&amp;gt; prints 'Hi, Tom' to STDOUT.&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/figure&gt;
-
-&lt;p&gt;Check out the &lt;a href=&quot;https://jekyllrb.com/docs/home&quot;&gt;Jekyll docs&lt;/a&gt; for more info on how to get the most out of Jekyll. File all bugs/feature requests at &lt;a href=&quot;https://github.com/jekyll/jekyll&quot;&gt;Jekyll’s GitHub repo&lt;/a&gt;. If you have questions, you can ask them on &lt;a href=&quot;https://talk.jekyllrb.com/&quot;&gt;Jekyll Talk&lt;/a&gt;.&lt;/p&gt;</content><author><name></name></author><summary type="html">You’ll find this post in your _posts directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run jekyll serve, which launches a web server and auto-regenerates your site when a file is updated.</summary></entry></feed>
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.title | xml_escape }}</title>
+    <description>{{ site.description | xml_escape }}</description>
+    <link>{{ site.url }}{{ site.baseurl }}/</link>
+    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
+      {% assign updates = site.updates | sort:"date" | reverse %}
+    {% for update in updates limit:10 %}
+      <item>
+        <title>{{ update.title | xml_escape }}</title>
+        <description>{{ update.content | xml_escape }}</description>
+        <pubDate>{{ update.date | date_to_rfc822 }}</pubDate>
+        <link>{{ update.url | prepend: site.baseurl | prepend: site.url }}</link>
+        <guid isPermaLink="true">{{ update.url | prepend: site.baseurl | prepend: site.url }}</guid>
+      </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
`/feed.xml` provides an RSS feed of the Tari developer updates 

#84 

Example output: 

```xml
<rss version="2.0">
<channel>
<title>The Tari Project</title>
<description>
Tari's mission is to be a decentralized platform that empowers anyone to create digitally scarce things people love.
</description>
<link>http://localhost:4000/</link>
<atom:link href="http://localhost:4000/feed.xml" rel="self" type="application/rss+xml"/>
<pubDate>Wed, 01 Sep 2021 10:18:18 +0200</pubDate>
<lastBuildDate>Wed, 01 Sep 2021 10:18:18 +0200</lastBuildDate>
<generator>Jekyll v4.0.0</generator>
<item>
<title>Tari Base Node 0.9.5 Released</title>
<description>
<h2 id="testnet-sha-mining-pool">Testnet SHA mining pool</h2> <p>The development community has set up a test SHA3 mining pool at <a href="https://miningcore.tarilabs.com/">https://miningcore.tarilabs.com/</a>. See <a href="https://github.com/tari-project/tari#tari-sha3-mining">here</a> for instructions on setting up the <code class="highlighter-rouge">tari_mining_node</code> to mine against it.</p> <h2 id="tari-base-node-095">Tari Base Node 0.9.5</h2> <p>Tari base node and console wallet v0.9.5 have been released. This version includes minor fixes, but mainly fixes a regression caused by v0.9.4 that caused nodes to get into an invalid state after a reorg.</p> <p>Binaries are available on the <a href="https://www.tari.com/downloads/">download page</a></p> <p>Please note that all base nodes should delete their database and resync the blockchain as part of this update.</p> <h2 id="release-notes">Release notes</h2> <h4 id="bug-fixes">Bug Fixes</h4> <ul> <li>show warnings on console (#3225) (<a href="https://github.com/tari-project/tari/commit/3291021c6e63778d4fa14ca6cb10c51681d8a5f5">3291021c</a>)</li> <li>edge-case fixes for wallet peer switching in console wallet (#3226) (<a href="https://github.com/tari-project/tari/commit/f577df8e9b34c6a823cc555b0fecfa2153ddd7e0">f577df8e</a>)</li> <li>chain error caused by zero-conf transactions and reorgs (#3223) (<a href="https://github.com/tari-project/tari/commit/f04042732a78bf3dc98d1aee7bf5b032e398010c">f0404273</a>)</li> <li>bug in wallet base node peer switching (#3217) (<a href="https://github.com/tari-project/tari/commit/878c317be9226da342cef439af2bc0024d1eb77f">878c317b</a>)</li> <li>division by zero (<a href="https://github.com/tari-project/tari/commit/8a988e1cd5bd4c49660819494949305963d08173">8a988e1c</a>)</li> <li>improve p2p RPC robustness (#3208) (<a href="https://github.com/tari-project/tari/commit/211dcfdb70eb774f9f2c3cdd080d6db7a24cb46c">211dcfdb</a>)</li> <li><strong>wallet:</strong> add NodeId to console wallet Who Am I tab (#3213) (<a href="https://github.com/tari-project/tari/commit/706ff5e59185f8088add19ac8654f29cc4ab1145">706ff5e5</a>)</li> <li><strong>wallet_ffi:</strong> fix division by zero during recovery (#3214) (<a href="https://github.com/tari-project/tari/commit/abd3d84965651285c72ecbcca1c401f3e54ad28c">abd3d849</a>)</li> </ul> <h4 id="features">Features</h4> <ul> <li>add <code class="highlighter-rouge">ping()</code> to all comms RPC clients (#3227) (<a href="https://github.com/tari-project/tari/commit/b5b62238cf7512abb38803c426369ebbcc8fe540">b5b62238</a>)</li> </ul> <h4 id="breaking-changes">Breaking Changes</h4> <ul> <li>base nodes should delete their database and resync</li> </ul>
</description>
<pubDate>Tue, 24 Aug 2021 00:00:00 +0200</pubDate>
<link>
http://localhost:4000/updates/2021-08-24-update-60.html
</link>
<guid isPermaLink="true">
http://localhost:4000/updates/2021-08-24-update-60.html
</guid>
</item>
...
```