### PR TITLE
feat: pull request title check

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,0 +1,20 @@
+name: PR
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install
+        run: |
+          npm install -g @commitlint/cli @commitlint/config-conventional
+          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
+      - name: lint
+        run: |
+          echo "${{github.event.pull_request.title}}" | commitlint


### PR DESCRIPTION
This PR adds a lint check for pull request titles to ensure they conform to the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

This will help ensure that these follow the same convention across repositories.

This has been carried over from https://github.com/tari-project/tari.