### PR TITLE
fix: wrong link key in update 70

### DIFF
--- a/_updates/2022-01-28-update-70.md
+++ b/_updates/2022-01-28-update-70.md
@@ -51,7 +51,7 @@ Last but certainly not least, Tari [Aurora] has been polished up and now support
 [tari codebase]: https://github.com/tari-project/tari
 [mining tutorials]: {% link _updates/2022-01-24-update-69.md %}
 [new swag]: https://store.tarilabs.com
-[21 billion tari]: https://github.com/tari-project/tari/pull/3744/files#diff-ae80bdd3829687321f5f4ead11265f6e22a3a931ddf0001a1b4065a7d9c19e18R319
+[21 billion testnet Tari]: https://github.com/tari-project/tari/pull/3744/files#diff-ae80bdd3829687321f5f4ead11265f6e22a3a931ddf0001a1b4065a7d9c19e18R319
 [aurora]: https://aurora.tari.com
 [yat]: https://y.at
 [updates]: https://aurora.tari.com/updates/


### PR DESCRIPTION
updates link that's not rendering 

