### PR TITLE
fix: specify invalidation path

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -26,6 +26,7 @@ jobs:
           folder: "_site"
           bucket: ${{ secrets.S3_BUCKET }}
           bucket-region: ${{ secrets.S3_REGION }}
+          invalidation: "/*"
           dist-id: ${{ secrets.CDN_ID }}
           delete-removed: true
           private: false


### PR DESCRIPTION
The CDN validation wasn't working with this action. Ideally, you'd only specify the files that change, but this global invalidation should work as well.