### PR TITLE
feat: update 100

### DIFF
--- a/_updates/2023-02-17-update-100.md
+++ b/_updates/2023-02-17-update-100.md
@@ -9,16 +9,20 @@ title: "Tari Base Node v0.45.0 Released on StageNet"
 class: subpage
 ---
 
-## Tari Protocol 0.45.0 Released: Your Wait for Mainnet Continues
+## Tari Protocol 0.45.0 Released: Approaching mainnet one minor release at a time
 
 It's that time again! The Tari protocol team is excited to announce the release of version 0.45.0, bringing a number of new features and improvements to the network. This release also marks an important milestone in our development with big news - wait for it - we've launched the Tari StageNet! Yes, you heard it right. We know, you're excited about the Mainnet, but trust me, this is almost as good.
 
 ### What's so special about StageNet?
 After several iterations of testnets with cool names like our currently running Esme, Igor, and our previously retired Dibbler, Weatherwax, Ridcully, and Stibbons (RIP ✌️), we're approaching a time that requires a stable testnet that mirrors our future Mainnet as closely as possible. And that's what StageNet is all about. It's a long-lived, stable testnet that won't reset often, because we know how annoying that can be. You can experiment with the network and test new features risk-free just as they should run on Mainnet.
 
-We won't be getting rid of our named testnets though! They still play an integral part in the development of the Tari network. This is where features are tested a little more fast and lose. We'll do our best not to, but these networks may see breakage sometimes. Or a new one may crop up to test a specific subset of features. For example right now our two running named testnets exist for different reasons. Our `Esme` network has been our stable-er testnet prior to `StageNet`. It sees new features and enhancements as they come out, and supports our mobile wallets [Tari Aurora](https://aurora.tari.com/) on [iOS](https://apps.apple.com/us/app/tari-aurora/id1503654828) and [Android](https://play.google.com/store/apps/details?id=com.tari.android.wallet). Where our `Igor` testnet is used in the development of our [DAN Layer](https://www.tari.com/updates/2023-02-01-update-99.html) and sees frequent resets to help support the rapid pace of the development team.
+We won't be getting rid of our named testnets though. They still play an integral part in the development of the Tari network, and are where we can play a little more fast and loose with features. We'll do our best not to, but these networks may see breakage sometimes. Or a new one may crop up to test a specific subset of features. For example, right now our two running named testnets exist for different reasons. 
 
-I know what you're thinking. Without Mainnet, what's the difference between this new stable StageNet and the previous ones? And here's the answer: It's all in how we're shepherding it. We're transitioning to an 8-week release cycle schedule! Yes, you heard it right. We may not have a Mainnet yet, but we're gonna start developing like we do. StageNet will get new updates every 8 weeks, just like the Mainnet will someday soon™️. This is a big change for our protocol team's workflow, and we're excited to iron out the kinks early to ensure a smoother Mainnet transition.
+Our `Esme` network has been our stable-er testnet prior to `StageNet`. It sees new features and enhancements as they come out, and supports our mobile wallets [Tari Aurora](https://aurora.tari.com/) on [iOS](https://apps.apple.com/us/app/tari-aurora/id1503654828) and [Android](https://play.google.com/store/apps/details?id=com.tari.android.wallet). 
+
+Our `Igor` testnet is used in the development of the [DAN Layer](https://www.tari.com/updates/2023-02-01-update-99.html) and sees frequent resets to help support the rapid pace of the development team.
+
+I know what you're thinking. Without Mainnet, what's the difference between this new stable StageNet and the previous ones? And here's the answer: It's all in how we're shepherding it. We're transitioning to an 8-week release cycle schedule. Yes, you heard it right. We may not have a Mainnet yet, but we're gonna start developing like we do. StageNet will get new updates every 8 weeks, just like the Mainnet will soon™️. This is a big change for our protocol team's workflow, and we're excited to iron out the kinks early to ensure a smoother Mainnet transition.
 
 ### How this will look in the immediate future:
 
@@ -26,7 +30,7 @@ Currently, the Protocol team is a highly functioning group, throwing out new fea
 
 Then, every so often we decide "hey we've done some really great work here, we should share it with people". And somebody will tag a release. This approach has gotten us to where we are but is a little unpredictable. So we're introducing a little more structure to our process.
 
-Going forward, we'll be taking a more meticulous approach to code selection and testing. We'll be running features through the gauntlet of our named testnets to ensure they're truly ready for prime time. No half-baked ideas making their way through, only once a feature has passed the rigorous testing, will it earn its place in the coveted StageNet branch. These features will be pruned and picked from our `developmnet` branch into the `stagenet` branch. Only then will a tag be created from this branch, and released for your ultimate enjoyment.
+Going forward, we'll be taking a more meticulous approach to code selection and testing. We'll be running features through the gauntlet of our named testnets to ensure they're truly ready for prime time. No half-baked ideas muddling their way in, only once a feature has passed the rigorous testing will it earn its place in the coveted StageNet branch. These features will be pruned and picked from our `development` branch into the `stagenet` branch. Only then will a tag be created from this branch, and released for your ultimate enjoyment.
 
 In practice this will be done with the addition of codified feature gates. These feature gates will allow us to perform conditional compilation when releasing new versions of our applications. When we release a new version for StageNet it will only contain hardened features we know are ready for prime time. While we can continue to release to our other testnets with additional features we're still trying out.
 

--- a/_updates/2023-02-17-update-100.md
+++ b/_updates/2023-02-17-update-100.md
@@ -1,0 +1,74 @@
+---
+layout: update
+tag: Developer Update
+date: 2023-02-17
+author: brianp
+thumbnail: update-background.jpg
+title: "Tari Base Node v0.45.0 Released on StageNet"
+"
+class: subpage
+---
+
+## Tari Protocol 0.45.0 Released: Your Wait for Mainnet Continues
+
+It's that time again! The Tari protocol team is excited to announce the release of version 0.45.0, bringing a number of new features and improvements to the network. This release also marks an important milestone in our development with big news - wait for it - we've launched the Tari StageNet! Yes, you heard it right. We know, you're excited about the Mainnet, but trust me, this is almost as good.
+
+### What's so special about StageNet?
+After several iterations of testnets with cool names like our currently running Esme, Igor, and our previously retired Dibbler, Weatherwax, Ridcully, and Stibbons (RIP ✌️), we're approaching a time that requires a stable testnet that mirrors our future Mainnet as closely as possible. And that's what StageNet is all about. It's a long-lived, stable testnet that won't reset often, because we know how annoying that can be. You can experiment with the network and test new features risk-free just as they should run on Mainnet.
+
+We won't be getting rid of our named testnets though! They still play an integral part in the development of the Tari network. This is where features are tested a little more fast and lose. We'll do our best not to, but these networks may see breakage sometimes. Or a new one may crop up to test a specific subset of features. For example right now our two running named testnets exist for different reasons. Our `Esme` network has been our stable-er testnet prior to `StageNet`. It sees new features and enhancements as they come out, and supports our mobile wallets [Tari Aurora](https://aurora.tari.com/) on [iOS](https://apps.apple.com/us/app/tari-aurora/id1503654828) and [Android](https://play.google.com/store/apps/details?id=com.tari.android.wallet). Where our `Igor` testnet is used in the development of our [DAN Layer](https://www.tari.com/updates/2023-02-01-update-99.html) and sees frequent resets to help support the rapid pace of the development team.
+
+I know what you're thinking. Without Mainnet, what's the difference between this new stable StageNet and the previous ones? And here's the answer: It's all in how we're shepherding it. We're transitioning to an 8-week release cycle schedule! Yes, you heard it right. We may not have a Mainnet yet, but we're gonna start developing like we do. StageNet will get new updates every 8 weeks, just like the Mainnet will someday soon™️. This is a big change for our protocol team's workflow, and we're excited to iron out the kinks early to ensure a smoother Mainnet transition.
+
+### How this will look in the immediate future:
+
+Currently, the Protocol team is a highly functioning group, throwing out new features and fixes whenever inspiration strikes. When work gets completed it gets merged into the `development` branch on our [Github repo](https://github.com/tari-project/tari/blob/development/changelog.md).
+
+Then, every so often we decide "hey we've done some really great work here, we should share it with people". And somebody will tag a release. This approach has gotten us to where we are but is a little unpredictable. So we're introducing a little more structure to our process.
+
+Going forward, we'll be taking a more meticulous approach to code selection and testing. We'll be running features through the gauntlet of our named testnets to ensure they're truly ready for prime time. No half-baked ideas making their way through, only once a feature has passed the rigorous testing, will it earn its place in the coveted StageNet branch. These features will be pruned and picked from our `developmnet` branch into the `stagenet` branch. Only then will a tag be created from this branch, and released for your ultimate enjoyment.
+
+In practice this will be done with the addition of codified feature gates. These feature gates will allow us to perform conditional compilation when releasing new versions of our applications. When we release a new version for StageNet it will only contain hardened features we know are ready for prime time. While we can continue to release to our other testnets with additional features we're still trying out.
+
+And with the introduction of a regular release cadence, you'll always know exactly when to expect the latest and greatest from us. No more sitting around wondering "when's the next release?" We've got you covered every 8 weeks.
+
+Sure, this means a bit more process and management for us, and one of the consequences of the feature gating process is the production of multiple binaries for different stages of development, and different networks. But we think it's worth it to ensure a smoother and more stable experience for everyone on the network.
+
+In the meantime, if you're interested in reading more about how code will move through our testnets or our 8-week release cycles, you can check out our [contributing guidelines](https://github.com/tari-project/tari/blob/development/Contributing.md#the-tari-release-proces). And if you're still waiting for the Mainnet, don't worry, we're just us eager as you are.
+
+And finally, here are the features and fixes we've made in version 0.45.0 to help stabilize the network. We've been working hard, we promise.
+
+### ⚠ BREAKING CHANGES
+
+* refactor database encryption (#5154)
+* update `Argon2` parameters (#5140)
+
+### Features
+
+* add `node {word} is in state {word}` ([33360cd](https://github.com/tari-project/tari/commit/33360cd1e9c8ad1dec1bd8193ca6cae1b79c81f4))
+* add get tari address to wallet ([1b0ed0b](https://github.com/tari-project/tari/commit/1b0ed0b99f8f36d7f04215b0ef846fdb13c095e7))
+* add graceful shutdown of base node ([c9797c5](https://github.com/tari-project/tari/commit/c9797c51e996fc043a6e4fd94ae1baebcd39d115))
+* add kill signal to cucumber nodes ([4cb21dc](https://github.com/tari-project/tari/commit/4cb21dc9148a32fbefae0017e984c634388f1543))
+* add shutdown clone ([ac956c9](https://github.com/tari-project/tari/commit/ac956c90d9ac3f78d7437ee24360c80204870341))
+* consolidate stealth payment code ([#5171](https://github.com/tari-project/tari/issues/5171)) ([b7747a2](https://github.com/tari-project/tari/commit/b7747a29c7032278b3ed88e13823d6e4fe7de45e))
+* fix miner ([7283eb2](https://github.com/tari-project/tari/commit/7283eb2c61e9e13313e256a1cc5ab191bb4f4b58))
+* gracefully shutdown grpc server ([947faf6](https://github.com/tari-project/tari/commit/947faf6559e6c16acdfe342c11c8c1ee99752d36))
+* refactor database encryption ([#5154](https://github.com/tari-project/tari/issues/5154)) ([41413fc](https://github.com/tari-project/tari/commit/41413fca3c66bf567777373d2b102c9d7ac0ea57))
+* refactor key-related field operations to be atomic ([#5178](https://github.com/tari-project/tari/issues/5178)) ([1ad79c9](https://github.com/tari-project/tari/commit/1ad79c946b3c67a3724f87d15ce55f29966d1e8b))
+* remove unused dependencies ([#5144](https://github.com/tari-project/tari/issues/5144)) ([a9d0f37](https://github.com/tari-project/tari/commit/a9d0f3711108ddb27599dc3e91834bb6cd02f821))
+* stagenet network ([#5173](https://github.com/tari-project/tari/issues/5173)) ([d2717a1](https://github.com/tari-project/tari/commit/d2717a1147e714f3978aaffb1e5af46986974335))
+* update `Argon2` parameters ([#5140](https://github.com/tari-project/tari/issues/5140)) ([4c4a056](https://github.com/tari-project/tari/commit/4c4a056f1f6623f6566b691a96c850ff905c0587))
+* wallet FFI cucumber ([795e717](https://github.com/tari-project/tari/commit/795e7178020b41bbda0510563e0ac0c2448eb359))
+* wallet password change ([#5175](https://github.com/tari-project/tari/issues/5175)) ([7f13fa5](https://github.com/tari-project/tari/commit/7f13fa5e64144c11b67201ab38bb55bdbb494680))
+
+
+### Bug Fixes
+
+* couple fixes for cucumber ([ad92e11](https://github.com/tari-project/tari/commit/ad92e1172682e602664ff512f9ce1495a566e473))
+* **dht/test:** ban peers who send empty encrypted messages  ([#5130](https://github.com/tari-project/tari/issues/5130)) ([86a9eaf](https://github.com/tari-project/tari/commit/86a9eaf700323a2794d2b71797ebf811ba3679b5))
+* do not propagate unsigned encrypted messages ([#5129](https://github.com/tari-project/tari/issues/5129)) ([d4fe7de](https://github.com/tari-project/tari/commit/d4fe7de1088aa986bf00d6ff4c31dd92659b4d95))
+* feature flag separation for validation ([#5137](https://github.com/tari-project/tari/issues/5137)) ([0e83463](https://github.com/tari-project/tari/commit/0e83463718001ef14564068f2087fb6dc50b0fa3))
+* panic on overflow in release mode ([#5150](https://github.com/tari-project/tari/issues/5150)) ([5f5808b](https://github.com/tari-project/tari/commit/5f5808b309cbf2416541652c7e2a4a923ef46e35))
+* potential ban ([#5146](https://github.com/tari-project/tari/issues/5146)) ([9892da6](https://github.com/tari-project/tari/commit/9892da6345468b798b0b669f010322f343fd9f4f))
+* **test:** broken address test ([#5134](https://github.com/tari-project/tari/issues/5134)) ([6b125af](https://github.com/tari-project/tari/commit/6b125af57570d48d5864158693f3ab935d23f6a9))
+* **wallet-grpc:** return correct available balance and add timelocked_balance ([#5181](https://github.com/tari-project/tari/issues/5181)) ([e001125](https://github.com/tari-project/tari/commit/e0011254ddbf4556a8b0ac2576869615c6549ccc))


### PR DESCRIPTION
Pushing up the second draft of the 0.45.0 and StageNet announcement. Bringing to attention our 8-week release cycles, and stabilized test net.