### PR TITLE
fix: remove video with broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,11 +89,6 @@ class: subpage home
             </div>
           </div>
           <h2 class="pb-2">Learn More About the Tari Protocol and Ecosystem</h2>
-          <div class="video-wrapper-full"><iframe src="https://player.vimeo.com/video/401484208" width="770" height="440" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div>
-          <div class="video-wrapper-scaled" style="width: 100%;">
-           <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/401484208?color=000000&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
-         
-          </div>
           <div class="row graphic-boxes-wrapper">
             <div class="col-lg-6 col-md-6 col-sm-6">
               <div class="graphic-box">


### PR DESCRIPTION
Video on the homepage is no longer on Vimeo, causing the video link to break.
Removed the iframe from the page.