### PR TITLE
fix: css error on side menu

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1861,14 +1861,12 @@ body.page- #call-to-action {
 }
 
 .nav-wallet-icon{
-  position: absolute;
   max-width: 18px;
       margin-left: 6px;
     margin-top: 1px;
 }
 
 .nav-explorer-icon{
-  position: absolute;
   max-width: 15px;
       margin-left: 6px;
     margin-top: 1px;


### PR DESCRIPTION
When clicking on Mobile Wallet, Block Explorer or Downloads, the icon moves over the text.
I removed the extra absolute positioning that gets added to the menu item when clicking on it.

![tari-dot-com-error](https://github.com/tari-project/tari-dot-com/assets/87762061/68673268-9bcd-420d-93e2-5de60bb259e3)
