### PR TITLE
feat: substack newsletter subscription forms

### DIFF
--- a/_includes/newsletter-subscribe.html
+++ b/_includes/newsletter-subscribe.html
@@ -1,22 +1,21 @@
 <div id="newsletter">
-  <form name="newsletterForm">
-    <input
-      required="required"
-      id="emailInput"
-      name="email"
-      type="email"
-      placeholder="Enter your email to get updates"
-    />
-    <button id="emailSubmit" type="submit">
-      <span id="emailSubmitText">
-        Subscribe
-      </span>
-      <img
-        id="emailSubmitImg"
-        class="email-success"
-        src="{{ site.baseurl }}/assets/icons/check.svg"
-        alt="success icon"
-      />
-    </button>
-  </form>
+  <div id="custom-substack-embed"></div>
 </div>
+
+<script>
+  window.CustomSubstackWidget = {
+    substackUrl: "tari.substack.com",
+    placeholder: "Enter your email to get updates",
+    buttonText: "Subscribe",
+    theme: "custom",
+    colors: {
+      primary: "#ffffff",
+      input: "#FFFFFF",
+      email: "#000000",
+      text: "#FFFFFF",
+    }
+  };
+  </script>
+  <script src="https://substackapi.com/widget.js" async></script>
+  
+

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -15,7 +15,7 @@
 
 
 <div class="col-lg-6 col-md-6 col-sm-12">
-  <a href="https://tari.substack.com" target="_blank">
+<a href="/subscribe/">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
         <div class="col-3 align-self-center">

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -917,6 +917,20 @@ lottie-player {
 #newsletter button span#emailSubmitText.hidden {
   opacity: 0;
 }
+#newsletter .success {
+  max-width: 380px !important;
+  font-size: 1.3rem !important;
+  text-align: center;
+  padding: 10px;
+  margin-bottom: 0 !important;
+}
+#newsletter .error {
+  max-width: 380px !important;
+  font-size: 1.3rem !important;
+  text-align: center;
+  padding: 10px;
+  margin-bottom: 0 !important;
+}
 
 /* copyright */
 #copyright {

--- a/subscribe.html
+++ b/subscribe.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Tari | Subscribe
+permalink: /subscribe/
+class: subpage blog
+---
+
+<div 
+style="
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    width: 100%;
+">    
+    <iframe src="https://tari.substack.com/embed" width="480" height="320" frameborder="0" scrolling="no"></iframe>
+</div>


### PR DESCRIPTION
Adds the substack subscription form to the top of the page, as well as a new page at tari.com/subscribe/ that links from the Substack card underneath Join the Discussion on the homepage.