### PR TITLE
fix: typo

### DIFF
--- a/_data/launchpad_downloads.yml
+++ b/_data/launchpad_downloads.yml
@@ -35,7 +35,7 @@
   version: MacOS 10.15.0 (Catalina) and higher
   source: https://github.com/tari-project/tari-launchpad
   background-image: /assets/img/downloads/launchpad-mac.mp4
-  video-poster: /assets/img/downloads/mac.png
+  video-poster: /assets/img/downloads/Mac.png
   tutorial-video: /launchpad-guide/
   logo: /img/downloads/apple-logo.svg
   logo-active: /img/downloads/apple-logo-active.svg

--- a/_data/suite_downloads.yml
+++ b/_data/suite_downloads.yml
@@ -37,7 +37,7 @@
   version: MacOS 10.15.0 (Catalina) and higher
   source: https://github.com/tari-project/tari
   background-image: /assets/img/downloads/mac.mp4
-  video-poster: /assets/img/downloads/mac.png
+  video-poster: /assets/img/downloads/Mac.png
   tutorial-video: /dibbler-install-guides/
   logo: /img/downloads/apple-logo.svg
   logo-active: /img/downloads/apple-logo-active.svg


### PR DESCRIPTION
`/assets/img/downloads/mac.png` is returning 404 due to incorrect casing