### PR TITLE
feat: update mining guide

### DIFF
--- a/_data/launchpad_downloads.yml
+++ b/_data/launchpad_downloads.yml
@@ -19,8 +19,7 @@
   defaultActive: active
   ctaText: Download for Ubuntu
   filter_spec: ubuntu
-  archOptions:
-    [{ value: x86_64, label: x86_64 }, { value: arm64, label: arm64 }]
+  archOptions: [{ value: x86_64, label: x86_64 }]
   networkOptions: [{ value: nextnet, label: Nextnet }]
 - type: Mac
   elementID: mac
@@ -43,7 +42,7 @@
   ctaText: Download for Mac
   filter_spec: osx-10.15
   archOptions:
-    [{ value: x86_64, label: x86_64 }, { value: arm64, label: arm64 }]
+    [{ value: arm64, label: arm64 }, { value: x86_64, label: x86_64 }]
   networkOptions: [{ value: nextnet, label: Nextnet }]
 - type: Windows
   elementID: windows

--- a/downloads.html
+++ b/downloads.html
@@ -20,7 +20,7 @@ class: subpage blog
         </p>
 
       </div>
-      <p>The Tari base node software is designed to be easy to set up and to run silently in the background. <a href="https://github.com/tari-project/tari/blob/development/README.md" target="_blank">Learn more about using the binaries</a>. Note: if your operating system does not currently have binary, you must compile from source.
+      <p>The Tari base node software is designed to be easy to set up and to run silently in the background. <a href="{{ site.baseurl }}/updates/2024-01-24-update-127" target="_blank">Learn more about using the binaries</a>. Note: if your operating system does not currently have binary, you must compile from source.
       </p>
       <div class="updates-banner">
         <div class="d-flex">


### PR DESCRIPTION
Updated the mining guide link on the downloads page
Updated the order of the architecture options on the Launchpad downloads page - made arm64 the default for Mac and removed it from Linux for now