### PR TITLE
chore: update discord link

### DIFF
--- a/_includes/side-navigation.html
+++ b/_includes/side-navigation.html
@@ -131,7 +131,7 @@
         <li><a href="https://twitter.com/tari" target="_blank">Twitter</a></li>
         <li><a href="https://www.youtube.com/channel/UCFjcsEiAtr9mC1Yt0uJ-3xA" target="_blank">YouTube</a></li>
         <li><a href="https://tari.substack.com/" target="_blank">Substack</a></li>
-        <li><a href="https://discord.gg/q3Sfzb8S2V" target="_blank">Discord</a></li>
+        <li><a href="https://discord.gg/tari" target="_blank">Discord</a></li>
         <li><a href="https://github.com/tari-project" target="_blank">GitHub</a></li>
       </ul>
 

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -1,6 +1,6 @@
 <div class="row graphic-boxes-small-wrapper">
   <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12">
-   <a href="https://discord.gg/q3Sfzb8S2V" target="_blank">
+   <a href="https://discord.gg/tari" target="_blank">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
         <div class="col-2 align-self-center"><img src="{{ site.baseurl }}/assets/img/discord.svg" alt="" /></div>
@@ -52,7 +52,7 @@
       <div class="graphic-box-small-content">
         <div class="col-2 align-self-center">
           <img src="{{ site.baseurl }}/assets/img/irc.jpg" alt="" />
-        </div>  
+        </div>
         <div class="col-10">
           <h4>IRC #tari</h4>
           <p>Mirror of the Tari #dev discord channel</p>

--- a/_updates/2021-09-28-update-61.md
+++ b/_updates/2021-09-28-update-61.md
@@ -62,7 +62,7 @@ unencumbered code base.
 
 If you're as excited about Tari as we are, help us get to our ultimate goal and get involved! Comment on our RFCs,
 contribute code, docs, or answer questions in our [Telegram group](https://t.me/tariproject) or our shiny new
-[Discord server](https://discord.gg/q3Sfzb8S2V).
+[Discord server](https://discord.gg/tari).
 
 Tari Labs is a steward of the Tari project, and they are hiring! If you're a Rust developer, designer, or front-end
 engineer and want to bring the future of digital assets into the present, [they want to talk](https://tarilabs.com/contribute/).

--- a/_updates/2021-11-11-update-63.md
+++ b/_updates/2021-11-11-update-63.md
@@ -66,4 +66,4 @@ Follow their development here:
 
 ### Hack on the future of Digital Assets @ Tari
 
-As always, come join us to chat about ongoing development in the `dev` channel on our [Discord server](https://discord.gg/q3Sfzb8S2V), or on IRC in the `#tari-dev` channel on the [Libera.Chat](https://libera.chat) IRC network.
+As always, come join us to chat about ongoing development in the `dev` channel on our [Discord server](https://discord.gg/tari), or on IRC in the `#tari-dev` channel on the [Libera.Chat](https://libera.chat) IRC network.

--- a/_updates/2021-11-25-update-65.md
+++ b/_updates/2021-11-25-update-65.md
@@ -80,6 +80,6 @@ We'd like to wish everyone a very happy Thanksgiving. We are incredibly grateful
 
 As always, come join us to chat about ongoing development in the `dev` channel on our [Discord server], or on IRC in the `#tari-dev` channel on the [Libera.Chat] IRC network.
 
-[discord server]: https://discord.gg/q3Sfzb8S2V
+[discord server]: https://discord.gg/tari
 [libera.chat]: https://libera.chat
 [telegram]: https://t.me/tariproject

--- a/_updates/2022-01-06-update-67.md
+++ b/_updates/2022-01-06-update-67.md
@@ -71,5 +71,5 @@ There's still no official date for mainnet launch. When this changes, you'll be 
 [development branch]: https://github.com/tari-project/tari
 [RFC]: https://rfc.tari.com/RFC-0300_DAN.html
 [Yat]: https://y.at/
-[Discord]: https://discord.gg/q3Sfzb8S2V
+[Discord]: https://discord.gg/tari
 [weatherwax branch]: https://github.com/tari-project/tari/tree/weatherwax

--- a/_updates/2022-01-28-update-70.md
+++ b/_updates/2022-01-28-update-70.md
@@ -60,6 +60,6 @@ Last but certainly not least, Tari [Aurora] has been polished up and now support
 
 As always, come join us to chat about ongoing development in the `dev` channel on our [Discord server], or on IRC in the `#tari-dev` channel on the [Libera.Chat] IRC network.
 
-[discord server]: https://discord.gg/q3Sfzb8S2V
+[discord server]: https://discord.gg/tari
 [libera.chat]: https://libera.chat
 [telegram]: https://t.me/tariproject

--- a/_updates/2022-05-10-update-76.md
+++ b/_updates/2022-05-10-update-76.md
@@ -13,7 +13,7 @@ class: subpage
 
 The main change in v0.32.0 is the reworked configuration system. Most users won't be aware of any changes, but now any spelling errors or invalid configuration settings will be picked up. Previously, any configuration settings would need to be mapped in code which meant that if a setting was never mapped, changing it in the config file would have no effect. More importantly, you'd have no indication of whether it was being used or if you'd even spelled it correctly. 
 
-If you are already running a Tari node, the easiest will be to delete the `.tari` folder and use the config file that is generated on startup. If you'd like to keep your settings, let us know on [Discord](https://discord.gg/qt9yznEW) and we'll help you migrate it.
+If you are already running a Tari node, the easiest will be to delete the `.tari` folder and use the config file that is generated on startup. If you'd like to keep your settings, let us know on [Discord](https://discord.gg/tari) and we'll help you migrate it.
 
 ### All Changes since v0.31.1
 

--- a/_updates/2022-05-17-update-77.md
+++ b/_updates/2022-05-17-update-77.md
@@ -42,6 +42,6 @@ You can check it out on [github](https://github.com/sdbondi/p2p-chess/releases).
 
 As always, come join us to chat about ongoing development in the `dev` channel on our [Discord server], or on IRC in the `#tari-dev` channel on the [Libera.Chat] IRC network.
 
-[discord server]: https://discord.gg/q3Sfzb8S2V
+[discord server]: https://discord.gg/tari
 [libera.chat]: https://libera.chat
 [telegram]: https://t.me/tariproject

--- a/_updates/2023-08-25-update-116.md
+++ b/_updates/2023-08-25-update-116.md
@@ -14,4 +14,4 @@ With the current code audits continuing and as we get closer to a release candid
 
 In addition to the reviewer's guide, we've started creating some [diagrams](https://github.com/tari-project/tari/pull/5651) to help new developers get aquainted to the codebase. Diagramming a whole system will take a while, so it's a work in progress right now, but we'll keep adding.
 
-If you're keen to get involved, let us know in [Telegram](https://t.me/tariproject) or [Discord](https://discord.gg/SGvXEuMDwS)
+If you're keen to get involved, let us know in [Telegram](https://t.me/tariproject) or [Discord](https://discord.gg/tari)

--- a/faq.html
+++ b/faq.html
@@ -11,7 +11,7 @@ class: subpage
 		<div class="new-section">
 			<h1>Frequently Asked Questions</h1>
 		</div>
-		<p>Below are answers to a few common questions about the Tari protocol. For other questions or additional clarity, please post your questions to the Tari community on <a href="https://discord.gg/q3Sfzb8S2V" target="_blank">Discord</a>.</p>
+		<p>Below are answers to a few common questions about the Tari protocol. For other questions or additional clarity, please post your questions to the Tari community on <a href="https://discord.gg/tari" target="_blank">Discord</a>.</p>
 		<div class="row justify-content-center" style="margin-top: 80px;">
       <div class="col-lg-12 col-xl-12">
         {% for faq in site.data.faq %}
@@ -23,7 +23,7 @@ class: subpage
         {% endfor %}
       </div>
     </div>
-    
+
   </div>
-  
+
 </section>

--- a/index.html
+++ b/index.html
@@ -358,11 +358,11 @@ class: subpage home
             </li>
           </ol>
           <p>Have questions? The Tari community prides itself on being open and inclusive. <strong>There are no dumb questions</strong>.
-            The best places to engage with the Tari developer community are on IRC or <a href="https://discord.gg/q3Sfzb8S2V" target="_blank">Discord#dev</a>.</p>
+            The best places to engage with the Tari developer community are on IRC or <a href="https://discord.gg/tari" target="_blank">Discord#dev</a>.</p>
 
           <h3>Spending testnet Tari (tXTR)</h3>
           <p>What can you do with tXTR besides experimenting with transactions? You can “spend” your hard-earned, infinite supply, fake Tari on exclusive one-of-a-kind items in the TTL (Tari Testnet Limited) store*. Everything in the store is denominated in tXTR (and is therefore free) except for shipping costs.
-            Check it out <a href="https://store.tarilabs.com" target="_blank" >here</a> and let folks know what you think on <a href="https://discord.gg/q3Sfzb8S2V" target="_blank">Discord</a> or IRC.</p>
+            Check it out <a href="https://store.tarilabs.com" target="_blank" >here</a> and let folks know what you think on <a href="https://discord.gg/tari" target="_blank">Discord</a> or IRC.</p>
           <p class="disclaimer" style="opacity: .7; font-size: 12px; margin-top: -20px;">* tXTR has no monetary value and cannot be exchanged for cash, cash equivalent, or other tokens or cryptocurrencies.</p>
 
            <!-- Store Banner  -->
@@ -571,7 +571,7 @@ class: subpage home
           <p>Found a bug? If it's a noncritical bug, please report it as a GitHub issue <a href="https://github.com/tari-project/tari/issues/new?assignees=&labels=bug-report&template=bug_report.md&title=%5BThanks%20for%20making%20Tari%20better%5D" target="_blank">here</a>. Thank you for helping to make the Tari project more robust, and reliable.</p>
 
           <h3>The Beginning of Your Journey</h3>
-          <p>The Tari project is undergoing continuous evolution. As a result there are always issues to tackle and improvements to make. The Tari community makes an effort to maintain a number of open issues that are a good place to start for new contributors. These issues are labeled in Tari project repos as “good first issue” and are usually refreshed every few months. Have questions? Please feel free to ask any question you have in #tari-dev on Libera.Chat, or on <a href="https://discord.gg/q3Sfzb8S2V" target="_blank">Discord#dev</a>. </p>
+          <p>The Tari project is undergoing continuous evolution. As a result there are always issues to tackle and improvements to make. The Tari community makes an effort to maintain a number of open issues that are a good place to start for new contributors. These issues are labeled in Tari project repos as “good first issue” and are usually refreshed every few months. Have questions? Please feel free to ask any question you have in #tari-dev on Libera.Chat, or on <a href="https://discord.gg/tari" target="_blank">Discord#dev</a>. </p>
 
           <h3>Protocol Issues</h3>
           <p>Oftentimes new contributors start with documentation related issues that tend to be quick wins and help them understand the protocol in greater detail before moving towards test writing and focusing on core protocol code. But feel free to choose your own adventure
@@ -666,7 +666,7 @@ class: subpage home
           <li>An inclusive community that cares deeply about each other, freedom, our world, and what you are creating</li>
         </ul>
         <h2>Learn More</h2>
-        <p>The best place to start is by engaging with the Tari community on <a href="https://discord.gg/q3Sfzb8S2V" target="_blank">Discord</a> or IRC.
+        <p>The best place to start is by engaging with the Tari community on <a href="https://discord.gg/tari" target="_blank">Discord</a> or IRC.
           We would love to hear about what you are working on, and how Tari can best support you.</p>
 
 

--- a/updates.html
+++ b/updates.html
@@ -14,7 +14,7 @@ class: subpage blog
     <p>The latest updates from developers contributing to the Tari protocol.</p>
 
   </div>
-  <p>Have questions or want to contribute? Join the community discussion on <a href="https://discord.gg/q3Sfzb8S2V" target="_blank">Discord</a> or #tari-dev on <a href="https://libera.chat/" target="_blank">Libera.Chat</a>. You can also subscribe to these updates using <a href="/feed.xml">the RSS Feed</a>.</p>
+  <p>Have questions or want to contribute? Join the community discussion on <a href="https://discord.gg/tari" target="_blank">Discord</a> or #tari-dev on <a href="https://libera.chat/" target="_blank">Libera.Chat</a>. You can also subscribe to these updates using <a href="/feed.xml">the RSS Feed</a>.</p>
 
     <div
       style="max-width: var(--max-content-width);"


### PR DESCRIPTION
The discord invite link was revoked somewhere, somehow. This update refreshes all Discord update links with one that is hopefully longer-lived.