### PR TITLE
Fix: Remove duplicate heading on Dev Update

### DIFF
--- a/_updates/2024-10-04-update-134.md
+++ b/_updates/2024-10-04-update-134.md
@@ -4,10 +4,10 @@ tag: Developer Update
 date: 2024-10-04
 author: solivagant
 thumbnail: update-133.png
-title: Developer Update October 4th
+title: Developer Update October 4
 class: subpage
 ---
-# Developer Update October 4th
+
 We’ve got a lot to share with you this update, with new features and improvements across Tari’s projects. Let’s start with what has been a core focus for us over the past two months - the release of Tari Universe.
 
 ## Welcome to the Universe


### PR DESCRIPTION
Removed the duplicate heading on the latest dev update (Oct 4 2024).