### PR TITLE
fix: universe css conflict

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,7 +39,6 @@
 
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/githubIssues.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/downloads.css" />
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/universe.css?v=4" />
 
 <link rel="apple-touch-icon" sizes="57x57" href="{{ site.baseurl }}/assets/favicon/apple-icon-57x57.png" />
 <link rel="apple-touch-icon" sizes="60x60" href="{{ site.baseurl }}/assets/favicon/apple-icon-60x60.png" />

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@ layout: default
 title: Tari
 class: subpage home
 ---
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/universe.css?v=4" />
 
 <section id="slide-content" class="main">
   {% include newsletter-subscribe.html %}


### PR DESCRIPTION
Moved the reference to the universe.css file from the head to index.html, so it's not available globally
It was causing conflicts in one of the dev update posts, due to the `#universe` id
Jekyll generates ids for titles, so the Universe title was mistakenly getting styles from this css file