### PR TITLE
fix(ui): fix homepage community links layout on mobile

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,18 +8,18 @@
 <meta property="og:title" content="Tari" />
 <meta property="og:description" content="The protocol for digital assets" />
 {% if page.og_image %}
-    <meta property="og:image" content="{{ site.url }}{{ page.og_image }}" />
+<meta property="og:image" content="{{ site.url }}{{ page.og_image }}" />
 {% else %}
-    <meta property="og:image" content="{{ site.url }}assets/img/meta-image.jpg" />
+<meta property="og:image" content="{{ site.url }}assets/img/meta-image.jpg" />
 {% endif %}
 <meta property="og:url" content="{{ site.url }}" />
 
 <meta name="twitter:title" content="Tari" />
 <meta name="twitter:description" content="The protocol for digital assets" />
 {% if page.og_image %}
-    <meta name="twitter:image" content="{{ site.url }}{{ page.og_image }}" />
+<meta name="twitter:image" content="{{ site.url }}{{ page.og_image }}" />
 {% else %}
-    <meta name="twitter:image" content="{{ site.url }}assets/img/meta-image.jpg" />
+<meta name="twitter:image" content="{{ site.url }}assets/img/meta-image.jpg" />
 {% endif %}
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@tari" />
@@ -28,7 +28,7 @@
 
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/normalize.css" />
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css?v=2" />
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css?v=3" />
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/animsition.min.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/animate.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/faq.css" />

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -1,102 +1,73 @@
 <div class="row graphic-boxes-small-wrapper">
-  <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12">
-   <a href="https://discord.gg/tari" target="_blank">
+  <a href="https://discord.gg/tari" target="_blank">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
-        <div class="col-2 align-self-center"><img src="{{ site.baseurl }}/assets/img/discord.svg" alt="" /></div>
-        <div class="col-10">
+        <img src="{{ site.baseurl }}/assets/img/discord.svg" alt="" />
+        <div>
           <h4>Discord</h4>
           <p>The primary Tari community hangout</p>
         </div>
       </div>
     </div>
   </a>
-</div>
 
-
-<div class="col-lg-6 col-md-6 col-sm-12">
-<a href="/subscribe/">
+  <a href="/subscribe/">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
-        <div class="col-2 align-self-center">
-          <img src="{{ site.baseurl }}/assets/img/substack.jpg" alt="" />
-        </div>
-        <div class="col-10">
+        <img src="{{ site.baseurl }}/assets/img/substack.jpg" alt="" />
+        <div>
           <h4>Substack</h4>
           <p>A curated weekly newsletter of protocol updates</p>
         </div>
       </div>
     </div>
   </a>
-</div>
 
-  <div class="col-lg-6 col-md-6 col-sm-12">
-    <a href="https://t.me/tariproject" target="_blank">
-      <div class="graphic-box-small">
-        <div class="graphic-box-small-content">
-          <div class="col-2 align-self-center">
-            <img src="{{ site.baseurl }}/assets/img/telegram.jpg" alt="" />
-          </div>
-          <div class="col-10">
-            <h4>Telegram</h4>
-            <p>A slightly noisier place to discuss Tari</p>
-          </div>
+  <a href="https://t.me/tariproject" target="_blank">
+    <div class="graphic-box-small">
+      <div class="graphic-box-small-content">
+        <img src="{{ site.baseurl }}/assets/img/telegram.jpg" alt="" />
+        <div>
+          <h4>Telegram</h4>
+          <p>A slightly noisier place to discuss Tari</p>
         </div>
       </div>
-    </a>
-  </div>
+    </div>
+  </a>
 
-<div class="col-lg-6 col-md-6 col-sm-12">
   <a href="https://libera.chat/" target="_blank">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
-        <div class="col-2 align-self-center">
-          <img src="{{ site.baseurl }}/assets/img/irc.jpg" alt="" />
-        </div>
-        <div class="col-10">
+        <img src="{{ site.baseurl }}/assets/img/irc.jpg" alt="" />
+        <div>
           <h4>IRC #tari</h4>
           <p>Mirror of the Tari #dev discord channel</p>
         </div>
       </div>
     </div>
   </a>
-</div>
 
-
-
-<div class="col-lg-6 col-md-6 col-sm-12">
   <a href="https://twitter.com/tari" target="_blank">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
-        <div class="col-2 align-self-center">
-          <img src="{{ site.baseurl }}/assets/img/twitter.jpg" alt="" />
-        </div>
-        <div class="col-10">
+        <img src="{{ site.baseurl }}/assets/img/twitter.jpg" alt="" />
+        <div>
           <h4>Twitter</h4>
           <p>Announcements and fun</p>
         </div>
       </div>
     </div>
   </a>
-</div>
 
-<div class="col-lg-6 col-md-6 col-sm-12">
   <a href="https://www.reddit.com/r/tari" target="_blank">
     <div class="graphic-box-small">
       <div class="graphic-box-small-content">
-        <div class="col-2 align-self-center">
-          <img src="{{ site.baseurl }}/assets/img/reddit.jpg" alt="" />
-        </div>
-
-        <div class="col-10">
+        <img src="{{ site.baseurl }}/assets/img/reddit.jpg" alt="" />
+        <div>
           <h4>Reddit</h4>
           <p>Conversations regarding privacy, cryptography, the Tari protocol, traditions, philosophy, and anything else that is of interest to the community</p>
         </div>
-
       </div>
     </div>
   </a>
 </div>
-
-</div>
-

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1012,7 +1012,7 @@ lottie-player {
 }
 
 .btn2 {
-  height: calc(5.3 * var(--root-size));
+  min-height: calc(5.3 * var(--root-size));
   display: inline-block;
   border-radius: calc(0.3 * var(--root-size));
   padding: calc(1.7 * var(--root-size)) calc(2 * var(--root-size));
@@ -1786,10 +1786,13 @@ body.page- #call-to-action {
 }
 
 .graphic-boxes-small-wrapper {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   margin-top: 40px;
   position: relative !important;
+  gap: 20px;
 }
+
 .graphic-boxes-small-wrapper a {
   color: black;
 }
@@ -1815,7 +1818,7 @@ body.page- #call-to-action {
 
 .graphic-box-small-content h4 {
   margin: 0 !important;
-  margin-bottom: 10px !important;
+  margin-bottom: 4px !important;
 }
 
 .graphic-box-small:hover {
@@ -1828,17 +1831,34 @@ body.page- #call-to-action {
   position: relative;
   display: flex;
   width: 100%;
+  align-items: center;
+
+  gap: 30px;
 }
 
 .graphic-box-small-content img {
-  max-width: 50px !important;
+  width: 50px !important;
+  height: 50px !important;
   position: relative;
   border-radius: 5px;
+  flex: unset !important;
 }
 
 .graphic-box-small-content p {
   margin: 0px !important;
   line-height: 20px !important;
+}
+
+@media only screen and (max-width: 991px) {
+  .graphic-boxes-small-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .graphic-box-small-content {
+    gap: 20px;
+    align-items: unset;
+  }
 }
 
 /* Wallet Banner */


### PR DESCRIPTION
The homepage community links are broken on mobile. This PR simplifies the markup to clean up and fix the issue.

This UI appears in 2 places. Under "Get Involved" and under "Developer Community".

BEFORE:

![CleanShot 2024-12-06 at 14 56 50](https://github.com/user-attachments/assets/da366a29-198e-49a2-83d3-78956405e733)

AFTER:

![CleanShot 2024-12-06 at 15 02 09](https://github.com/user-attachments/assets/762c46a0-2752-4db2-8fc2-2a18dd80e1f7)

