### PR TITLE
Fix: Dev Update 141 og_image field

### DIFF
--- a/_updates/2025-01-23-update-141.md
+++ b/_updates/2025-01-23-update-141.md
@@ -4,7 +4,7 @@ tag: Developer Update
 date: 2025-01-23
 author: solivagant
 thumbnail: update-background.jpg
-og_image: update-background-141.png
+og_image: /assets/updates/img/update-background-141.png
 title: New Year, New Developments
 class: subpage
 ---

--- a/_updates/2025-01-24-update-141.md
+++ b/_updates/2025-01-24-update-141.md
@@ -1,7 +1,7 @@
 ---
 layout: update
 tag: Developer Update
-date: 2025-01-23
+date: 2025-01-24
 author: solivagant
 thumbnail: update-background.jpg
 og_image: /assets/updates/img/update-background-141.png


### PR DESCRIPTION
Needed to correct og_image field as it works slightly differently from the thumbnail field. This should fix the display issue on the custom image for the update. Will also adjust the date to reflect the more likely publish date for tomorrow.