### PR TITLE
Dev Update 141 Fix 2

### DIFF
--- a/_updates/2025-01-24-update-141.md
+++ b/_updates/2025-01-24-update-141.md
@@ -3,7 +3,7 @@ layout: update
 tag: Developer Update
 date: 2025-01-24
 author: solivagant
-thumbnail: update-background.jpg
+thumbnail: update-background-141.png
 og_image: /assets/updates/img/update-background-141.png
 title: New Year, New Developments
 class: subpage


### PR DESCRIPTION
Still following up on this. The og_image does not override the thumbnail image. I have updated this to point to the new update image. I believe this should replace the headers being used by dev update on the site while the og_image is used for external links.